### PR TITLE
fix dispose issue

### DIFF
--- a/lib/src/widgets/wave_form_player.dart
+++ b/lib/src/widgets/wave_form_player.dart
@@ -372,15 +372,17 @@ class _WaveformPlayerState extends State<WaveformPlayer>
   }
 
   void _onPositionChanged(Duration position) {
-    if (!_isSeeking && _isPlaying) {
+    if (!_isSeeking && _isPlaying && mounted) {
       _updatePositionWithAnimation(position);
     }
   }
 
   void _onPlayerStateChanged(PlayerState state) {
-    setState(() {
-      _isPlaying = state.playing;
-    });
+    if (mounted) {
+      setState(() {
+        _isPlaying = state.playing;
+      });
+    }
 
     _updateLoadingState(state);
 
@@ -391,9 +393,11 @@ class _WaveformPlayerState extends State<WaveformPlayer>
 
   void _updateLoadingState(PlayerState state) {
     if (state.processingState == ProcessingState.ready) {
-      setState(() {
-        _isLoading = false;
-      });
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
     }
   }
 


### PR DESCRIPTION
It's possible for the `_audioPlayer.playerStateStream` to continue emitting, even after the widget has already been removed from the widget tree. This results in an exception, when `setState` is called.